### PR TITLE
Replace deprecated mocha.opts with modern .mocharc.json configuration

### DIFF
--- a/TypeScript/.mocharc.json
+++ b/TypeScript/.mocharc.json
@@ -1,0 +1,4 @@
+{
+  "require": ["ts-node/register"],
+  "spec": "**/*.spec.ts"
+}

--- a/TypeScript/package.json
+++ b/TypeScript/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "compile": "tsc",
     "start": "./node_modules/.bin/ts-node app/app.ts",
-    "test": "mocha -r ts-node/register '**/*.spec.ts'"
+    "test": "mocha"
   },
   "author": "Peter 'Code Cop' Kofler",
   "license": "BSD-3-Clause",

--- a/TypeScript/test/mocha.opts
+++ b/TypeScript/test/mocha.opts
@@ -1,4 +1,0 @@
---compilers ts-node/register
---require source-map-support/register
---recursive
-test/**/*.spec.ts


### PR DESCRIPTION
- Removed deprecated test/mocha.opts file
- Created .mocharc.json with same configuration options
- Updated package.json test script to use modern mocha configuration
- Fixes deprecation warning about mocha.opts no longer being supported